### PR TITLE
Fix reset - only send button when pressed, not when released

### DIFF
--- a/priiloader/include/Input.h
+++ b/priiloader/include/Input.h
@@ -38,6 +38,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #define INPUT_BUTTON_START			0x00001000
 #define INPUT_BUTTON_STM			0x10000000
 
+#define RESET_UNPRESSED (((*(vu32*)0xCC003000)>>16)&1)
+
 s8 Input_Init( void );
 void Input_Shutdown( void );
 u32 Input_ScanPads( void );

--- a/priiloader/source/Input.cpp
+++ b/priiloader/source/Input.cpp
@@ -85,13 +85,14 @@ void *kbd_thread (void *arg) {
 	return NULL;
 }
 
+//the STM event is triggered when the buttons are pressed, or released.
 void HandleSTMEvent(u32 event)
 {
 	struct timeval press;
 	gettimeofday(&press, NULL);	
 
-	//after the 2 second of being init, we wont accept input
-	if(_time_init.tv_sec+5 >= press.tv_sec)
+	//after the 1 second of being init, we wont accept input
+	if(_time_init.tv_sec+1 >= press.tv_sec)
 		return;
 
 	//only accept input every +/- 200ms
@@ -106,7 +107,8 @@ void HandleSTMEvent(u32 event)
 			_STM_input_pressed = INPUT_BUTTON_DOWN;
 			break;
 		case STM_EVENT_RESET:
-			_STM_input_pressed = INPUT_BUTTON_A;
+			//only send press when the button is pressed, not unpressed
+			_STM_input_pressed = (RESET_UNPRESSED == 0)?INPUT_BUTTON_A:0;
 			break;
 		default:
 			_STM_input_pressed = 0;
@@ -114,14 +116,12 @@ void HandleSTMEvent(u32 event)
 	}
 	return;
 }
-
 s8 Input_Init( void ) 
 {
 	if(_input_init != 0)
 		return 1;
 
-	s8 r;
-	r = PAD_Init();
+	s8 r = PAD_Init();
 	r |= WPAD_Init();
 	gettimeofday(&_time_init, NULL);
 
@@ -175,6 +175,7 @@ u32 Input_ScanPads( void )
 u32 Input_ButtonsDown( bool _overrideSTM )
 {
 	u32 pressed = 0;
+
 	if(_STM_input_pressed != 0)
 	{
 		if(_overrideSTM)

--- a/priiloader/source/main.cpp
+++ b/priiloader/source/main.cpp
@@ -2763,7 +2763,7 @@ int main(int argc, char **argv)
 	Input_ScanPads();
 	
 	//Check reset button state
-	if(((Input_ButtonsDown() & INPUT_BUTTON_B) == 0) && (((*(vu32*)0xCC003000)>>16)&1) == 1 && magicWord == 0) //if( ((*(vu32*)0xCC003000)>>16)&1 && !CheckMagicWords())
+	if(((Input_ButtonsDown() & INPUT_BUTTON_B) == 0) && RESET_UNPRESSED == 1 && magicWord == 0)
 	{
 		//Check autoboot settings
 		switch( Bootstate )


### PR DESCRIPTION
Tested this fix for #214, works properly. Priiloader only detects pressing the button, not releasing it, so you can hold down the RESET button to load Priiloader as long as you want, without it booting straight into the System Menu, 