### PR TITLE
Master / Slave hack support

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -1,0 +1,64 @@
+# Hacks
+
+Priiloader includes a file called `hacks_hash.ini` (see the priiloader 
+subfolder), which contains a bunch of hacks that Priiloader can apply to the 
+System Menu. Each hack has a name that is surrounded by square brackets 
+(like `[Name]`), and then a bunch of parameters explaining the patch. 
+
+Required parameters are `minversion=` and `maxversion=`. These two parameters 
+define which System Menu versions the hack is compatible with. For example, 
+a hack that only works on 4.1 in all four regions would have the parameters
+`minversion=448` and `maxversion=454`. 
+
+The parameter `amount=` used to contain the amount of patch instructions for 
+this hack. It is no longer read by current versions of Priiloader, but it 
+can't hurt to add it anyways. 
+
+After the versions and amounts are defined, the hack includes definitions for 
+the actual data to patch. For each patch there'll either be an `offset=` 
+parameter (in order to patch at a certain memory offset), or a `hash=` 
+parameter (in order to search for a certain string and use its location as 
+an offset). A patch using the `hash=` parameter is preferred, as it usually 
+works on multiple versions and not just on one. 
+
+The offset or hash parameters look like this: `offset=0x81234567` or 
+`hash=0x12345678,0x98765432`. The offset parameter would include the patch
+at the fixed memory address 0x81234567, the hash parameter would add the patch
+at the RAM address that contains the specified bytes(`12 34 56 78 98 76 54 32`). 
+
+In addition to these parameters there needs to be a `patch=` parameter, which
+(same syntax as `hash=`) includes the bytes to write to the found location, 
+the actual patch data to replace in the system menu RAM. 
+
+An example hack using these parameters could look like this: 
+
+    [Example Hack]
+    maxversion=514
+    minversion=514
+    amount=2
+    hash=0x2c030000,0x48024451
+    patch=0x2c03ffff,0x48024451,0x4e800020
+    offset=0x81200000
+    patch=0x9421ffd0,0x7c0802a6,0x90010034,0x38610008
+    
+This results in two patches being applied to a 4.3E system menu.
+One at whatever address the hash value is found, and one at the fixed 
+address 0x8120000. 
+
+## Additional master hack / sub hack functionality
+
+If a hack contains the `require=` parameter, that means it needs another hack
+to function. The `require=` parameter can contain a string identifying the
+required hack. The hack that provides the required functionality must then
+provide a `master=` parameter with the same parameter. 
+
+This causes the master hack (with the `master=` parameter) to be hidden from
+the hacks menu in Priiloader. It will only be enabled once one of the sub 
+hacks that requires the master hack to be present is enabled. 
+
+This can be useful if you have a hack where a large part is version-independant,
+but a small additional part is different in each version. You can then create
+a large hidden master hack with the independant code, and several small sub
+hacks for the different System Menu versions that all require different offsets. 
+
+An example for that functionality can be found in the Wiimmfi patcher hack. 

--- a/priiloader/include/hacks.h
+++ b/priiloader/include/hacks.h
@@ -34,6 +34,8 @@ struct system_patch {
 
 struct system_hack {
 	std::string desc;
+	std::string masterID;
+	std::string requiredMasterID;
 	u16 max_version = 0;
 	u16 min_version = 0;
 	std::vector< system_patch > patches;

--- a/priiloader/source/main.cpp
+++ b/priiloader/source/main.cpp
@@ -144,7 +144,8 @@ void SysHackHashSettings( void )
 	//loop hacks file and see which one we show
 	for( unsigned int i=0; i<system_hacks.size(); ++i)
 	{
-		if( system_hacks[i].max_version >= SysVersion && system_hacks[i].min_version <= SysVersion)
+		if( system_hacks[i].max_version >= SysVersion && system_hacks[i].min_version <= SysVersion
+				&& system_hacks[i].masterID.length() == 0)
 		{
 			hack_index hack;
 			hack.desc.assign(system_hacks[i].desc,0,39);
@@ -321,7 +322,8 @@ handle_hacks_s_fail:
 				u32 i = 0;
 				for(i=0; i<system_hacks.size(); ++i)
 				{
-					if( system_hacks[i].max_version >= SysVersion && system_hacks[i].min_version <= SysVersion)
+					if( system_hacks[i].max_version >= SysVersion && system_hacks[i].min_version <= SysVersion
+							&& system_hacks[i].masterID.length() == 0)
 					{
 						if( cur_off == j++)
 							break;
@@ -1429,6 +1431,37 @@ void BootMainSysMenu( u8 init )
 		u32 size = 0;
 		u32 patch_cnt = 0;
 		u8* patch_ptr = NULL;
+		
+		// Force enable the required master hack: 
+		for(u32 i = 0;i < system_hacks.size();i++)
+		{
+			if (system_hacks[i].requiredMasterID.length() > 0 && states_hash[i] == 1) 
+			{
+				u32 found_requirement = 0; 
+				
+				// If the hack has a requirement and is enabled, 
+				// find and activate the requirement as well
+				for (u32 j = 0; j < system_hacks.size(); j++) 
+				{
+					if (system_hacks[i].requiredMasterID.compare(system_hacks[j].masterID) == 0) 
+					{
+						// Found hack that provides the requirement
+						// Make sure it's compatible
+						u32 sysver = GetSysMenuVersion(); 
+						if (system_hacks[j].min_version <= sysver &&
+							sysver <= system_hacks[j].max_version) {
+							// enable
+							found_requirement = 1; 
+							states_hash[j] = 1; 
+						}
+					}
+				}
+				
+				// didn't find requirement, disable hack
+				if (found_requirement == 0) states_hash[i] = 0; 
+				
+			}
+		}
 		
 		for(u32 i = 0;i < system_hacks.size();i++)
 		{


### PR DESCRIPTION
As discussed in #222, I started playing around with master / slave hacks. 

This means, that there can be one master hack that is not shown in the Hacks Menu, that is compatible with all versions of the System Menu, and then there can be multiple Sub-Hacks / slave hacks that are version-dependant, which add additional version-dependant code related to the master hack. 

This supports  two new parameters in the hacks_hash.ini file, `provide` and `require`. 
A hack that has a `provide` parameter will be considered a master hack, and will be completely invisible in the Hacks menu (and will be disabled by default). 
A hack that has a `require` parameter that is the same as an existing master hack's `provide` value, will cause the corresponding master hack to be enabled and disabled simultaneously. 

This means, there can be one hack with `provide=wiimmfi-v1` that includes most of the Wiimmfi patch which is compatible with all versions, and then there will be many hacks, one for each version, with `require=wiimmfi-v1` which include the region-dependant patches. 

Let me know if this is something you would want to add, or if we want to stick to the full patches for Wiimmfi for each region. As of now, switching from full patches to this master/slave system brings the size of the Wiimmfi patch down from 88 kB to 10 kB, and that difference is only going to increase when support for more system menu versions is added in the future. 

Making this a draft PR as well because I need to do some more testing to see if this works reliably. 