### PR TITLE
Updated hacks_hash

### DIFF
--- a/priiloader/hacks_hash.ini
+++ b/priiloader/hacks_hash.ini
@@ -516,12 +516,6 @@ minversion=288
 amount=1
 hash=0x41820008,0x48002179
 patch=0x60000000
-[Lock System Menu with Black Screen]
-maxversion=516
-minversion=416
-amount=1
-hash=0x4bffe7e5,0x38bd05a8
-patch=0x60000000
 [No-Delete HAXX,JODI,DVDX,DISC,DISK,RZDx]
 maxversion=4610
 minversion=480
@@ -534,3 +528,17 @@ minversion=1
 amount=1
 hash=0x7f06c378,0x7f25cb78,0x387e02
 patch=0x3B200001,0x3B0000F9
+[Remove Deflicker]
+maxversion=518
+minversion=288
+amount=5
+hash=0x0608080a,0x0C0A0808
+patch=0x06000015,0x16150000
+hash=0x0608080a,0x0C0A0808
+patch=0x06000015,0x16150000
+hash=0x0608080a,0x0C0A0808
+patch=0x06000015,0x16150000
+hash=0x0608080a,0x0C0A0808
+patch=0x06000015,0x16150000
+hash=0x0608080a,0x0C0A0808
+patch=0x06000015,0x16150000


### PR DESCRIPTION
Removed black screen system menu hack, and added Remove Deflicker hack
Ref: https://gbatemp.net/threads/possible-to-disable-the-wiis-de-flicker-filter.477163/post-9509597