### PR TITLE
Start Priiloader the first time its installed

### DIFF
--- a/priiloader/include/settings.h
+++ b/priiloader/include/settings.h
@@ -88,6 +88,12 @@ enum PreferredMountPoint {
 	MOUNT_USB
 };
 
+enum LoadSettingsResult {
+	LOADSETTINGS_OK,
+	LOADSETTINGS_FAIL,
+	LOADSETTINGS_INI_CREATED
+};
+
 extern Settings *settings;
 
 u32 GetSysMenuVersion( void );

--- a/priiloader/include/settings.h
+++ b/priiloader/include/settings.h
@@ -99,7 +99,7 @@ extern Settings *settings;
 u32 GetSysMenuVersion( void );
 u32 GetSysMenuIOS( void );
 u32 SGetSetting( u32 s );
-void LoadSettings( void );
+LoadSettingsResult LoadSettings( void );
 int SaveSettings( void );
 
 #endif

--- a/priiloader/source/main.cpp
+++ b/priiloader/source/main.cpp
@@ -2862,18 +2862,7 @@ int main(int argc, char **argv)
 	LoadHBCStub();
 	gprintf("\"Magic Priiloader word\": %x - %x",*(vu32*)MAGIC_WORD_ADDRESS_2 ,*(vu32*)MAGIC_WORD_ADDRESS_1);
 
-	bool IsFirstTimeUse = false;
-	switch (LoadSettings())
-	{
-		case LOADSETTINGS_FAIL:
-			// Do nothing, errors are handled later
-			break;
-		case LOADSETTINGS_INI_CREATED:
-			IsFirstTimeUse = true;
-			/* fallthrough */
-		case LOADSETTINGS_OK:
-			break;
-	}
+	bool isFirstTimeUse = LoadSettings() == LOADSETTINGS_INI_CREATED;
 	if(SGetSetting(SETTING_DUMPGECKOTEXT) == 1)
 	{
 		InitMounts(_mountCallback);
@@ -2899,7 +2888,7 @@ int main(int argc, char **argv)
 	Input_ScanPads();
 	
 	//Check reset button state, boot to priiloader if first time
-	if(!IsFirstTimeUse && ((Input_ButtonsDown() & INPUT_BUTTON_B) == 0) && RESET_UNPRESSED == 1 && magicWord == 0)
+	if(!isFirstTimeUse && ((Input_ButtonsDown() & INPUT_BUTTON_B) == 0) && RESET_UNPRESSED == 1 && magicWord == 0)
 	{
 		//Check autoboot settings
 		switch( Bootstate )

--- a/priiloader/source/main.cpp
+++ b/priiloader/source/main.cpp
@@ -2861,7 +2861,19 @@ int main(int argc, char **argv)
 	AddMem2Area (14*1024*1024, OTHER_AREA);
 	LoadHBCStub();
 	gprintf("\"Magic Priiloader word\": %x - %x",*(vu32*)MAGIC_WORD_ADDRESS_2 ,*(vu32*)MAGIC_WORD_ADDRESS_1);
-	LoadSettings();
+
+	bool IsFirstTimeUse = false;
+	switch (LoadSettings())
+	{
+		case LOADSETTINGS_FAIL:
+			// Do nothing, errors are handled later
+			break;
+		case LOADSETTINGS_INI_CREATED:
+			IsFirstTimeUse = true;
+			/* fallthrough */
+		case LOADSETTINGS_OK:
+			break;
+	}
 	if(SGetSetting(SETTING_DUMPGECKOTEXT) == 1)
 	{
 		InitMounts(_mountCallback);
@@ -2886,8 +2898,8 @@ int main(int argc, char **argv)
 	usleep(500000);
 	Input_ScanPads();
 	
-	//Check reset button state
-	if(((Input_ButtonsDown() & INPUT_BUTTON_B) == 0) && RESET_UNPRESSED == 1 && magicWord == 0)
+	//Check reset button state, boot to priiloader if first time
+	if(!IsFirstTimeUse && ((Input_ButtonsDown() & INPUT_BUTTON_B) == 0) && RESET_UNPRESSED == 1 && magicWord == 0)
 	{
 		//Check autoboot settings
 		switch( Bootstate )


### PR DESCRIPTION
This makes it so that Wii Minis don't require a USB keyboard when
installing Priiloader, because now it's going to launch automatically,
without having to hold down any keys, after which the user can use the
Wiimote to configure Priiloader.