### PR TITLE
Move boot error message down 1 line to accomodate the larger main menu.

### DIFF
--- a/priiloader/source/error.cpp
+++ b/priiloader/source/error.cpp
@@ -33,49 +33,49 @@ u8 error = 0;
 
 void ShowAutoBootError(void)
 {
-	PrintFormat( 0, 16, (rmode->viHeight)-144, "Error autobooting systemmenu!");
+	PrintFormat( 0, 16, (rmode->viHeight)-128, "Error autobooting systemmenu!");
 	switch( error )
 	{
 		case ERROR_SYSMENU_TIKNOTFOUND:
-			PrintFormat( 0, 16, (rmode->viHeight)-128, "Ticket not found!");
+			PrintFormat( 0, 16, (rmode->viHeight)-112, "Ticket not found!");
 			break;
 		case ERROR_SYSMENU_TIKSIZEGETFAILED:
-			PrintFormat( 0, 16, (rmode->viHeight)-128, "Could not get ticket size!");
+			PrintFormat( 0, 16, (rmode->viHeight)-112, "Could not get ticket size!");
 			break;
 		case ERROR_SYSMENU_TIKREADFAILED:
-			PrintFormat( 0, 16, (rmode->viHeight)-128, "Could not read ticket!");
+			PrintFormat( 0, 16, (rmode->viHeight)-112, "Could not read ticket!");
 			break;
 		case ERROR_SYSMENU_ESDIVERFIY_FAILED:
-			PrintFormat( 0, 16, (rmode->viHeight)-128, "ES_DiVerfiy failed! Is the IOS patched?");
+			PrintFormat( 0, 16, (rmode->viHeight)-112, "ES_DiVerfiy failed! Is the IOS patched?");
 			break;
 		case ERROR_SYSMENU_IOSSTUB:
-			PrintFormat( 0, 16, (rmode->viHeight)-128, "The going to load IOS was detected as Stub!");
+			PrintFormat( 0, 16, (rmode->viHeight)-112, "The going to load IOS was detected as Stub!");
 			break;
 		case ERROR_SYSMENU_GETTMDFAILED:
-			PrintFormat( 0, 16, (rmode->viHeight)-128, "Could not get TMD!");
+			PrintFormat( 0, 16, (rmode->viHeight)-112, "Could not get TMD!");
 			break;
 		case ERROR_SYSMENU_BOOTNOTFOUND:
-			PrintFormat( 0, 16, (rmode->viHeight)-128, "Boot file not found!");
+			PrintFormat( 0, 16, (rmode->viHeight)-112, "Boot file not found!");
 			break;
 		case ERROR_SYSMENU_BOOTOPENFAILED:
-			PrintFormat( 0, 16, (rmode->viHeight)-128, "Could not open boot file!");
+			PrintFormat( 0, 16, (rmode->viHeight)-112, "Could not open boot file!");
 			break;
 		case ERROR_SYSMENU_BOOTREADFAILED:
-			PrintFormat( 0, 16, (rmode->viHeight)-128, "Could not read boot file!");
+			PrintFormat( 0, 16, (rmode->viHeight)-112, "Could not read boot file!");
 			break;
 		case ERROR_SYSMENU_BOOTGETSTATS:
-			PrintFormat( 0, 16, (rmode->viHeight)-128, "Could not get boot stats!");
+			PrintFormat( 0, 16, (rmode->viHeight)-112, "Could not get boot stats!");
 			break;
 	}
 	return;
 }
 void ShowHacksError(void)
 {
-	PrintFormat( 0, 16, (rmode->viHeight)-144, "Error loading hacks!");
+	PrintFormat( 0, 16, (rmode->viHeight)-128, "Error loading hacks!");
 	switch( error )
 	{
 		case ERROR_HACKS_TO_LONG:
-			PrintFormat( 0, 16, (rmode->viHeight)-128, "Line in hacks file is to long");
+			PrintFormat( 0, 16, (rmode->viHeight)-112, "Line in hacks file is to long");
 			break;
 	}
 	return;
@@ -93,63 +93,63 @@ void ShowError ( void )
 			case ERROR_NONE:
 				break;
 			case ERROR_BOOT_DOL_OPEN:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "Error autobooting file, try reinstalling!");
-				PrintFormat( 0, 16, (rmode->viHeight)-128, "Could not open file!");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "Error autobooting file, try reinstalling!");
+				PrintFormat( 0, 16, (rmode->viHeight)-112, "Could not open file!");
 				break;
 			case ERROR_BOOT_DOL_READ:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "Error autobooting file, try reinstalling!");
-				PrintFormat( 0, 16, (rmode->viHeight)-128, "Reading the file failed!");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "Error autobooting file, try reinstalling!");
+				PrintFormat( 0, 16, (rmode->viHeight)-112, "Reading the file failed!");
 				break;
 			case ERROR_BOOT_DOL_SEEK:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "Error autobooting file, try reinstalling!");
-				PrintFormat( 0, 16, (rmode->viHeight)-128, "Seek failed!");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "Error autobooting file, try reinstalling!");
+				PrintFormat( 0, 16, (rmode->viHeight)-112, "Seek failed!");
 				break;
 			case ERROR_BOOT_DOL_ENTRYPOINT:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "Error autobooting file, try reinstalling!");
-				PrintFormat( 0, 16, (rmode->viHeight)-128, "Entrypoint is unusable!");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "Error autobooting file, try reinstalling!");
+				PrintFormat( 0, 16, (rmode->viHeight)-112, "Entrypoint is unusable!");
 				break;
 			case ERROR_ISFS_INIT:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "ISFS_Initialize() failed");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "ISFS_Initialize() failed");
 				break;
 			case ERROR_BOOT_HBC:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "Error autobooting HBC, maybe title not installed?");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "Error autobooting HBC, maybe title not installed?");
 				break;
 			case ERROR_BOOT_BOOTMII:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "Error booting Bootmii IOS!");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "Error booting Bootmii IOS!");
 				break;
 			case ERROR_BOOT_ERROR:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "Error autobooting due problems with the settings.ini!");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "Error autobooting due problems with the settings.ini!");
 				break;
 			case ERROR_SYSMENU_FRONT_BUTTONS_FORBIDDEN:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "Error Entering Menu");
-				PrintFormat( 0, 16, (rmode->viHeight)-128, "Front buttons forbidden in this menu.");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "Error Entering Menu");
+				PrintFormat( 0, 16, (rmode->viHeight)-112, "Front buttons forbidden in this menu.");
 				break;
 			case ERROR_SETTING_OPEN:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "Problems with settings.ini!");
-				PrintFormat( 0, 16, (rmode->viHeight)-128, "Could not open/create file!");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "Problems with settings.ini!");
+				PrintFormat( 0, 16, (rmode->viHeight)-112, "Could not open/create file!");
 				break;
 			case ERROR_SETTING_WRITE:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "Problems with settings.ini!");
-				PrintFormat( 0, 16, (rmode->viHeight)-128, "Could not write file!");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "Problems with settings.ini!");
+				PrintFormat( 0, 16, (rmode->viHeight)-112, "Could not write file!");
 				break;
 			case ERROR_SETTING_READ:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "Problems with settings.ini!");
-				PrintFormat( 0, 16, (rmode->viHeight)-128, "Could not read file!");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "Problems with settings.ini!");
+				PrintFormat( 0, 16, (rmode->viHeight)-112, "Could not read file!");
 				break;
 			case ERROR_THREAD_CREATE:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "LWP_CreateThread() failed!");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "LWP_CreateThread() failed!");
 				break;
 			case ERROR_MALLOC:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "malloc failed!");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "malloc failed!");
 				break;
 			case ERROR_STATE_CLEAR:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "failed to clear state!");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "failed to clear state!");
 				break;
 			case ERROR_SYSMENU_GENERAL:
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "Failed to load system menu!");
+				PrintFormat( 0, 16, (rmode->viHeight)-128, "Failed to load system menu!");
 				break;
 			case ERROR_DVD_BOOT_FAILURE:
-				PrintFormat(0, 16, (rmode->viHeight) - 144, "Failed to load from DVD drive!");
+				PrintFormat(0, 16, (rmode->viHeight)-128, "Failed to load from DVD drive!");
 				break;
 			case ERROR_SYSMENU_TIKNOTFOUND:
 			case ERROR_SYSMENU_TIKSIZEGETFAILED:

--- a/priiloader/source/main.cpp
+++ b/priiloader/source/main.cpp
@@ -3130,8 +3130,8 @@ int main(int argc, char **argv)
 
 			if(error == ERROR_REFRESH)
 			{
-				PrintFormat( 0, 16, (rmode->viHeight)-144, "                                                             ");
 				PrintFormat( 0, 16, (rmode->viHeight)-128, "                                                             ");
+				PrintFormat( 0, 16, (rmode->viHeight)-114, "                                                             ");
 				error = ERROR_NONE;
 			}
 			else if (error > ERROR_NONE)


### PR DESCRIPTION
 A new main menu entry was added, but the error messages were never moved down. When an error happens, it would overlap with the "Settings" menu entry. Example: 
![before1](https://user-images.githubusercontent.com/45859969/188289768-629acf14-cfbe-4990-84e6-3c95bcb7181c.png)
![before2](https://user-images.githubusercontent.com/45859969/188289767-e5efce3f-ea91-481c-9549-f3454cfa7d6f.png)

This patch moves all error messages down 16px, removing the overlap. Pics: 
![after](https://user-images.githubusercontent.com/45859969/188289786-af8f1e43-968d-4aab-8d0c-b203d8924f9b.png)