### PR TITLE
Makefile: Fix git rev fallback path for non-git checkouts

### DIFF
--- a/priiloader/Makefile
+++ b/priiloader/Makefile
@@ -159,7 +159,7 @@ ifeq ($(wildcard ../.git/.),)
 	@echo
 	@echo '#define GIT_REV 0x'$(NUMBER) > ../Shared/gitrev.h
 	@echo '#define GIT_REV_STR "'$(NUMBER)'-no-git"' >> ../Shared/gitrev.h
-	@echo 'Using 0x'$(NUMBER)' as revision, ''$(NUMBER)'-no-git as revision string'
+	@echo 'Using 0x'$(NUMBER)' as revision, '$(NUMBER)'-no-git as revision string'
 else
 	@echo "#define GIT_REV 0x$(shell git rev-parse --verify --short HEAD)" > ../Shared/gitrev.h
 	@echo "#define GIT_REV_STR \"$(shell git describe --always --long --dirty)\"" >> ../Shared/gitrev.h


### PR DESCRIPTION
Looks like an extra quote got left behind when refactoring this in b0e74f0
Before:
```
make[1]: Entering directory '/home/apiroli/work/priiloader-me/priiloader'


!!!!!!WARNING!!!!!!!
--------------------
NOT BUILDING FROM GIT CHECKOUT. REV NUMBERS WILL NOT MAKE ANY SENSE


/bin/sh: 1: Syntax error: Unterminated quoted string
make[1]: *** [Makefile:162: pre_build] Error 2
```
After:
```
make[1]: Entering directory '/home/apiroli/work/priiloader-me/priiloader'


!!!!!!WARNING!!!!!!!
--------------------
NOT BUILDING FROM GIT CHECKOUT. REV NUMBERS WILL NOT MAKE ANY SENSE


Using 0x21477 as revision, 21477-no-git as revision string

-----------------------------------------------
compiling priiloader...
```
Fixes: #321 