### PR TITLE
add support for progressive + pal60 video mode forcing (for Launch Disc)

### DIFF
--- a/src/Shared/Video.cpp
+++ b/src/Shared/Video.cpp
@@ -64,6 +64,11 @@ const static void _configureVideoMode(GXRModeObj* videoMode, bool initConsole)
 	DCInvalidateRange(xfb, VIDEO_GetFrameBufferSize(rmode) + 0x100);
 	xfb = MEM_K0_TO_K1(xfb);
 
+	// set video mode register
+	*(vu32*)0x800000CC = VI_TVMODE_FMT(rmode->viTVMode);
+	DCFlushRange((void*)0x800000CC, 4);
+
+	//set video mode
 	VIDEO_SetBlack(true);
 	VIDEO_Configure(rmode);
 	VIDEO_Flush();

--- a/src/priiloader/source/DiscContent.cpp
+++ b/src/priiloader/source/DiscContent.cpp
@@ -80,8 +80,6 @@ void LaunchGamecubeDisc(void)
 	gprintf("video mode : 0x%02X -> 0x%02X", oldVideoMode, videoMode);
 	if (oldVideoMode != videoMode)
 		SYS_SetVideoMode(videoMode); // most gc games tested require this
-	*(vu32*)0x800000CC = videoMode > SYS_VIDEO_NTSC ? 0x00000001 : 0x00000000;
-	DCFlushRange((void*)0x80000000, 0x3200);
 
 	//set bootstate for when we come back & set reset state for gc mode
 	SetBootState(TYPE_UNKNOWN, FLAGS_STARTGCGAME, RETURN_TO_MENU, DISCSTATE_GC);
@@ -255,7 +253,7 @@ void LaunchWiiDisc(void)
 	//what is even the purpose of this?
 	settime(secs_to_ticks(time(NULL) - 946684800));
 
-	s8 videoMode = SetVideoModeForTitle(gameID);
+	SetVideoModeForTitle(gameID);
 
 	//disc related pokes to finish it off
 	//see memory map @ https://wiibrew.org/w/index.php?title=Memory_Map
@@ -264,7 +262,7 @@ void LaunchWiiDisc(void)
 	*(vu32*)0x80000024 = 0x00000001;				// Version
 	*(vu32*)0x80000028 = 0x01800000;				// Memory Size (Physical) 24MB
 	*(vu32*)0x8000002C = 0x00000023;				// Production Board Model
-	*(vu32*)0x800000CC = videoMode > SYS_VIDEO_NTSC ? 0x00000001 : 0x00000000;	// Video Mode
+													// Video Mode (set by ConfigureVideoMode)
 	*(vu32*)0x800000E4 = 0x8008f7b8;				// Thread Pointer
 	*(vu32*)0x800000F0 = 0x01800000;				// Dev Debugger Monitor Address
 	*(vu32*)0x800000F8 = 0x0E7BE2C0;				// Bus Clock Speed

--- a/src/priiloader/source/titles.cpp
+++ b/src/priiloader/source/titles.cpp
@@ -430,7 +430,6 @@ s8 SetVideoModeForTitle(u32 lowerTitleId)
 				gprintf("NTSC 480i");
 			}
 			videoMode = SYS_VIDEO_NTSC;
-			gprintf("NTSC");
 			break;
 		default:
 			gprintf("unknown titleRegion");


### PR DESCRIPTION
as discussed in #376; this is my sketch for the solution:

1. determine render mode from system settings (`CONF_GetProgressiveScan`, `VIDEO_HaveComponentCable` and `CONF_GetEuRGB60`).
2. set render mode register within the `VIDEO_Configure` wrapper function, determined from render mode.
3. ~~remove gamecube-disc-launch `SYS_SetVideoMode` call cos undocumented and not used in non-gc-disc paths (note: i'm unsure if this function supports the value 5 for PAL60 and don't want it to undo the register setting in step 2).~~
4. ~~add video mode setting to title-launch path (i didn't spot earlier it wasn't being called because the called function has "Title" in its name so i assumed it would be lol)~~

edit: 3 needs to stay and 4 doesn't fix issue #376... in fact, it rebreaks it after having been fixed by a different change (#379) lol. 1 and 2 seem like they would make disc loading more robust and correct (e.g. starting pal discs in progressive) tho so i've left them up here

this still doesn't support stuff like mpal and so isn't totally libogc-compliant but that's why we have the libogc dev on-hand to sort it out fully :3

not tested, ~~not compiled, not checked by a language server even (i wasn't expecting to be doing any c++ :p)~~