### PR TITLE
viTVMode access macros + bugfixes

### DIFF
--- a/src/Shared/Video.cpp
+++ b/src/Shared/Video.cpp
@@ -78,7 +78,7 @@ const static void _configureVideoMode(GXRModeObj* videoMode, bool initConsole)
 	VIDEO_SetBlack(false);
 	VIDEO_Flush();
 	VIDEO_WaitVSync();
-	if (rmode->viTVMode & VI_NON_INTERLACE)
+	if (VI_TVMODE_MODE(rmode->viTVMode) == VI_NON_INTERLACE)
 		VIDEO_WaitVSync();
 
 	_videoInit = true;

--- a/src/Shared/Video.cpp
+++ b/src/Shared/Video.cpp
@@ -78,7 +78,7 @@ const static void _configureVideoMode(GXRModeObj* videoMode, bool initConsole)
 	VIDEO_SetBlack(false);
 	VIDEO_Flush();
 	VIDEO_WaitVSync();
-	if (VI_TVMODE_MODE(rmode->viTVMode) == VI_NON_INTERLACE)
+	if (VI_TVMODE_ISMODE(rmode->viTVMode, VI_NON_INTERLACE))
 		VIDEO_WaitVSync();
 
 	_videoInit = true;

--- a/src/Shared/Video.h
+++ b/src/Shared/Video.h
@@ -26,6 +26,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 extern GXRModeObj *rmode;
 extern void *xfb;
 
+// upstream these macros into libogc imo to complement VI_TVMODE (https://libogc.devkitpro.org/video__types_8h.html)
+#define VI_TVMODE_FMT(viTVMode)   (viTVMode >> 2)    // = VI_NTSC / VI_PAL / VI_MPAL / VI_DEBUG / VI_DEBUG_PAL / VI_EURGB60
+#define VI_TVMODE_MODE(viTVMode)  (viTVMode & 0b11)  // = VI_INTERLACE / VI_NON_INTERLACE / VI_PROGRESSIVE
+
 #define TEXT_OFFSET(X) ((((rmode->viWidth) / 2 ) - (strnlen((X), 128)*13/2))>>1)
 
 void InitVideo(void);

--- a/src/Shared/Video.h
+++ b/src/Shared/Video.h
@@ -22,13 +22,24 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 #include <gctypes.h>
 #include <ogc/gx_struct.h>
+#include <ogc/video_types.h>
 
 extern GXRModeObj *rmode;
 extern void *xfb;
 
-// upstream these macros into libogc imo to complement VI_TVMODE (https://libogc.devkitpro.org/video__types_8h.html)
+// upstream these macros into libogc to complement VI_TVMODE (https://libogc.devkitpro.org/video__types_8h.html)
+#ifndef VI_TVMODE_FMT
 #define VI_TVMODE_FMT(viTVMode)   (viTVMode >> 2)    // = VI_NTSC / VI_PAL / VI_MPAL / VI_DEBUG / VI_DEBUG_PAL / VI_EURGB60
+#endif
+#ifndef VI_TVMODE_MODE
 #define VI_TVMODE_MODE(viTVMode)  (viTVMode & 0b11)  // = VI_INTERLACE / VI_NON_INTERLACE / VI_PROGRESSIVE
+#endif
+#ifndef VI_TVMODE_ISFMT
+#define VI_TVMODE_ISFMT(viTVMode, fmt)    (VI_TVMODE_FMT(viTVMode) == fmt)
+#endif
+#ifndef VI_TVMODE_ISMODE
+#define VI_TVMODE_ISMODE(viTVMode, mode)  (VI_TVMODE_MODE(viTVMode) == mode)
+#endif
 
 #define TEXT_OFFSET(X) ((((rmode->viWidth) / 2 ) - (strnlen((X), 128)*13/2))>>1)
 

--- a/src/priiloader/source/DiscContent.cpp
+++ b/src/priiloader/source/DiscContent.cpp
@@ -79,7 +79,7 @@ void LaunchGamecubeDisc(void)
 	s8 videoMode = SetVideoModeForTitle(gameID);
 	gprintf("video mode : 0x%02X -> 0x%02X", oldVideoMode, videoMode);
 	if (oldVideoMode != videoMode)
-		SYS_SetVideoMode(videoMode);
+		SYS_SetVideoMode(videoMode); // most gc games tested require this
 	*(vu32*)0x800000CC = videoMode > SYS_VIDEO_NTSC ? 0x00000001 : 0x00000000;
 	DCFlushRange((void*)0x80000000, 0x3200);
 

--- a/src/priiloader/source/main.cpp
+++ b/src/priiloader/source/main.cpp
@@ -204,7 +204,7 @@ void SysHackHashSettings( void )
 			}
 
 			//ye, those tv's want a special treatment again >_>
-			if (VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan())
+			if (VI_TVMODE_ISFMT(rmode->viTVMode, VI_NTSC) || CONF_GetEuRGB60() || CONF_GetProgressiveScan())
 				max_pos = 14;
 			else
 				max_pos = 17;
@@ -1499,7 +1499,7 @@ void InstallLoadDOL( void )
 			}
 
 			//ye, those tv's want a special treatment again >_>
-			if( VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
+			if( VI_TVMODE_ISFMT(rmode->viTVMode, VI_NTSC) || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
 				max_pos = 14;
 			else
 				max_pos = 19;
@@ -2131,7 +2131,7 @@ void CheckForUpdate()
 		u8 line = 0;
 		u8 min_line = 0;
 		u8 max_line = 0;
-		if( VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
+		if( VI_TVMODE_ISFMT(rmode->viTVMode, VI_NTSC) || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
 			max_line = 12;
 		else
 			max_line = 17;

--- a/src/priiloader/source/main.cpp
+++ b/src/priiloader/source/main.cpp
@@ -204,7 +204,7 @@ void SysHackHashSettings( void )
 			}
 
 			//ye, those tv's want a special treatment again >_>
-			if (rmode->viTVMode == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan())
+			if (VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan())
 				max_pos = 14;
 			else
 				max_pos = 17;
@@ -1499,7 +1499,7 @@ void InstallLoadDOL( void )
 			}
 
 			//ye, those tv's want a special treatment again >_>
-			if( rmode->viTVMode == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
+			if( VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
 				max_pos = 14;
 			else
 				max_pos = 19;
@@ -2131,7 +2131,7 @@ void CheckForUpdate()
 		u8 line = 0;
 		u8 min_line = 0;
 		u8 max_line = 0;
-		if( rmode->viTVMode == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
+		if( VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
 			max_line = 12;
 		else
 			max_line = 17;

--- a/src/priiloader/source/titles.cpp
+++ b/src/priiloader/source/titles.cpp
@@ -393,13 +393,13 @@ s8 VideoRegionMatches(s8 titleRegion)
 
 s8 SetVideoModeForTitle(u32 lowerTitleId)
 {
-	//always set video, 
+	//always set video when launching disc
 	s8 titleRegion = GetTitleRegion(lowerTitleId);
 	GXRModeObj* vidmode = rmode;
 	s8 videoMode = 0;
 	switch (titleRegion)
 	{
-		//PAL
+		// i am unsure if always setting interlaced is correct here
 		case TITLE_PAL:
 			gprintf("PAL50");
 			// set 50Hz mode - incompatible with S-Video cables!
@@ -735,6 +735,7 @@ s32 LoadListTitles( void )
 					case 'Q':
 						gprintf("LoadListTitles : Region Mismatch ! %d -> %d", VI_TVMODE_FMT(rmode->viTVMode), titleRegion);
 						ShutdownVideo();
+						// calling SetVideoModeForTitle to force video mode here would inexplicably revert (correct) 480p to 480i sometimes; see issue #376
 						break;
 					case 'H':
 					case 'O':

--- a/src/priiloader/source/titles.cpp
+++ b/src/priiloader/source/titles.cpp
@@ -234,22 +234,15 @@ s8 GetTitleName(u64 id, u32 app, char* name, u8* unicodeName)
 			goto return_getTitle;
 		}
 
-		switch(fh >= 0)
+		if (fh >= 0)
 		{
 			//ES method
-			case true:
-			{
 				ret = ES_ReadContent(fh, (u8*)imetHeader, sizeof(IMET));
 				ES_CloseContent(fh);
 				if (ret < 0) 
 					throw "IMET ES_ReadContent " + std::to_string(ret);
-				break;
-			}
-
+		} else {
 			//ES method failed. remove tikviews from memory and fall back on ISFS method
-			case false:
-			default:
-			{
 				gprintf("GetTitleName : ES_OpenTitleContent error %d",fh);
 				char file[64] ATTRIBUTE_ALIGN(32);
 				sprintf(file, "/title/%08x/%08x/content/%08x.app", TITLE_UPPER(id), TITLE_LOWER(id), app);
@@ -272,8 +265,6 @@ s8 GetTitleName(u64 id, u32 app, char* name, u8* unicodeName)
 				ISFS_Close(fh);
 				if (ret < 0) 
 					throw "IMET ISFS_Read " + std::to_string(ret);
-				break;
-			}
 		}
 
 		mem_free(ticketViews);

--- a/src/priiloader/source/titles.cpp
+++ b/src/priiloader/source/titles.cpp
@@ -563,7 +563,7 @@ s32 LoadListTitles( void )
 	//eventho normally a tv would be able to show 23 titles; some TV's do 60hz in a horrible mannor 
 	//making title 23 out of the screen just like the main menu
 	s16 max_pos;
-	if( VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
+	if( VI_TVMODE_ISFMT(rmode->viTVMode, VI_NTSC) || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
 	{
 		//ye, those tv's want a special treatment again >_>
 		max_pos = 14;

--- a/src/priiloader/source/titles.cpp
+++ b/src/priiloader/source/titles.cpp
@@ -385,7 +385,7 @@ u8 GetTitleRegion(u32 lowerTitleId)
 
 s8 VideoRegionMatches(s8 titleRegion)
 {
-	switch (rmode->viTVMode)
+	switch (VI_TVMODE_FMT(rmode->viTVMode))
 	{
 		case VI_NTSC:
 		case VI_DEBUG:
@@ -572,7 +572,7 @@ s32 LoadListTitles( void )
 	//eventho normally a tv would be able to show 23 titles; some TV's do 60hz in a horrible mannor 
 	//making title 23 out of the screen just like the main menu
 	s16 max_pos;
-	if( rmode->viTVMode == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
+	if( VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
 	{
 		//ye, those tv's want a special treatment again >_>
 		max_pos = 14;
@@ -741,7 +741,7 @@ s32 LoadListTitles( void )
 					case 'N':
 					case 'P':
 					case 'Q':
-						gprintf("LoadListTitles : Region Mismatch ! %d -> %d", rmode->viTVMode, titleRegion);
+						gprintf("LoadListTitles : Region Mismatch ! %d -> %d", VI_TVMODE_FMT(rmode->viTVMode), titleRegion);
 						ShutdownVideo();
 						break;
 					case 'H':

--- a/tools/DacosLove/source/Global.cpp
+++ b/tools/DacosLove/source/Global.cpp
@@ -39,7 +39,7 @@ void InitVideo ( void )
 		rmode = VIDEO_GetPreferredMode(NULL);
 
 	//apparently the video likes to be bigger then it actually is on NTSC/PAL60/480p. lets fix that!
-	if( VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
+	if( VI_TVMODE_ISFMT(rmode->viTVMode, VI_NTSC) || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
 	{
 		//the correct one would be * 0.035 to be sure to get on the Action safe of the screen.
 		GX_AdjustForOverscan(rmode, rmode, 0, rmode->viWidth * 0.026 ); 
@@ -55,7 +55,7 @@ void InitVideo ( void )
 	VIDEO_Flush();
 
 	VIDEO_WaitVSync();
-	if(VI_TVMODE_MODE(rmode->viTVMode) == VI_NON_INTERLACE)
+	if(VI_TVMODE_ISMODE(rmode->viTVMode, VI_NON_INTERLACE))
 		VIDEO_WaitVSync();
 	vid_init = 1;
 	gdprintf("resolution is %dx%d",rmode->viWidth,rmode->viHeight);

--- a/tools/DacosLove/source/Global.cpp
+++ b/tools/DacosLove/source/Global.cpp
@@ -39,7 +39,7 @@ void InitVideo ( void )
 		rmode = VIDEO_GetPreferredMode(NULL);
 
 	//apparently the video likes to be bigger then it actually is on NTSC/PAL60/480p. lets fix that!
-	if( rmode->viTVMode == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
+	if( VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
 	{
 		//the correct one would be * 0.035 to be sure to get on the Action safe of the screen.
 		GX_AdjustForOverscan(rmode, rmode, 0, rmode->viWidth * 0.026 ); 
@@ -55,7 +55,7 @@ void InitVideo ( void )
 	VIDEO_Flush();
 
 	VIDEO_WaitVSync();
-	if(rmode->viTVMode&VI_NON_INTERLACE)
+	if(VI_TVMODE_MODE(rmode->viTVMode) == VI_NON_INTERLACE)
 		VIDEO_WaitVSync();
 	vid_init = 1;
 	gdprintf("resolution is %dx%d",rmode->viWidth,rmode->viHeight);

--- a/tools/DacosLove/source/main.cpp
+++ b/tools/DacosLove/source/main.cpp
@@ -580,7 +580,7 @@ void InstallLoadDOL(void)
 				sleep(5);
 				return;
 			}
-			if (VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan())
+			if (VI_TVMODE_ISFMT(rmode->viTVMode, VI_NTSC) || CONF_GetEuRGB60() || CONF_GetProgressiveScan())
 			{
 				//ye, those tv's want a special treatment again >_>
 				max_pos = 14;

--- a/tools/DacosLove/source/main.cpp
+++ b/tools/DacosLove/source/main.cpp
@@ -580,7 +580,7 @@ void InstallLoadDOL(void)
 				sleep(5);
 				return;
 			}
-			if (rmode->viTVMode == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan())
+			if (VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan())
 			{
 				//ye, those tv's want a special treatment again >_>
 				max_pos = 14;

--- a/tools/DacosLove/source/titles.cpp
+++ b/tools/DacosLove/source/titles.cpp
@@ -381,7 +381,7 @@ s32 LoadListTitles( void )
 	//eventho normally a tv would be able to show 23 titles; some TV's do 60hz in a horrible mannor 
 	//making title 23 out of the screen just like the main menu
 	s16 max_pos;
-	if( VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
+	if( VI_TVMODE_ISFMT(rmode->viTVMode, VI_NTSC) || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
 	{
 		//ye, those tv's want a special treatment again >_>
 		max_pos = 14;

--- a/tools/DacosLove/source/titles.cpp
+++ b/tools/DacosLove/source/titles.cpp
@@ -381,7 +381,7 @@ s32 LoadListTitles( void )
 	//eventho normally a tv would be able to show 23 titles; some TV's do 60hz in a horrible mannor 
 	//making title 23 out of the screen just like the main menu
 	s16 max_pos;
-	if( rmode->viTVMode == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
+	if( VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC || CONF_GetEuRGB60() || CONF_GetProgressiveScan() )
 	{
 		//ye, those tv's want a special treatment again >_>
 		max_pos = 14;

--- a/tools/LoadPriiloader/source/main.cpp
+++ b/tools/LoadPriiloader/source/main.cpp
@@ -320,7 +320,7 @@ int main(int argc, char **argv) {
 	VIDEO_SetBlack(false);
 	VIDEO_Flush();
 	VIDEO_WaitVSync();
-	if (vmode->viTVMode & VI_NON_INTERLACE)
+	if (VI_TVMODE_MODE(vmode->viTVMode) == VI_NON_INTERLACE)
 		VIDEO_WaitVSync();
     
 	// This function initialises the attached controllers

--- a/tools/LoadPriiloader/source/main.cpp
+++ b/tools/LoadPriiloader/source/main.cpp
@@ -320,7 +320,7 @@ int main(int argc, char **argv) {
 	VIDEO_SetBlack(false);
 	VIDEO_Flush();
 	VIDEO_WaitVSync();
-	if (VI_TVMODE_MODE(vmode->viTVMode) == VI_NON_INTERLACE)
+	if (VI_TVMODE_ISMODE(vmode->viTVMode, VI_NON_INTERLACE))
 		VIDEO_WaitVSync();
     
 	// This function initialises the attached controllers


### PR DESCRIPTION
A fix related to [libogc video_types.h](https://libogc.devkitpro.org/video__types_8h.html). Thruout the code, the whole of `GXRModeObj.viTVMode` was being erroneously compared to `VI_NTSC`, which is a VI_TVMODE_FMT rather than a full VI_TVMode. This patch adds two macros to invert the `VI_TVMODE(fmt, mode)` transformation and recover the FMT and the MODE (this should be upstreamed to libogc), and then applies the macros thruout the codebase. The changes are pretty much:
1. `rmode->viTVMode == VI_NTSC` → `VI_TVMODE_FMT(rmode->viTVMode) == VI_NTSC` (bugfix)
2. `rmode->viTVMode & VI_NON_INTERLACE` → `VI_TVMODE_MODE(rmode->viTVMode) == VI_NON_INTERLACE` (code readability; old code relied on hack that `VI_NON_INTERLACE` was the only enum out of three that was odd).

Consequently, `VideoRegionMatches` now works, so mismatched regions will actually call `ShutdownVideo()` in the title loading codepath, which fixes #376.

([finally](https://youtu.be/-hUIp3eUyKI?t=247))

The second commit in this patchset just fixes a compiler warning by replacing a switch(bool) with an if-else.

Both commits tested by loading NTSC-U VC Super Mario 64 on a PAL Wii in 480p. However, there are a couple of bugs to look out for:
1. Now, the video takes a few more seconds to initialise and misses more of the intro of SM64.
2. The names of the titles are all still showing up as ????????, which I think is a regression on the master branch.

My old attempt at fixing #376 is at #378, but it'll probably remain a draft since I don't have the means to test the other changes.
- ~~Currently it still boots NTSC-U SM64 at 480i but I believe the mistake is that I replaced the `ShutdownVideo()` call with `SetVideoModeForTitle` rather than just adding the latter~~ (edit: nvm lol, `SetVideoModeForTitle` actually switches it from 480p to 480i 🤦‍♂️).
- The code indicates the rather alarming bug that cross-region discs will get forced into interlaced tho, which is an obstacle to replacing GeckoOS with Priiloader for general-purpose speedrunning (I'm doing all this to streamline recommended setups).
- It also just seems handicapped in a few other ways, like say that the memory edit to set VI mode is `videoMode > SYS_VIDEO_NTSC ? 0x00000001 : 0x00000000;` rather than `VI_TVMODE_FMT(rmode->viTVMode)`.