### PR TITLE
port sadmenu's patches to priiloader

### DIFF
--- a/src/priiloader/hacks_hash.ini
+++ b/src/priiloader/hacks_hash.ini
@@ -731,3 +731,16 @@ hash=0x41810090,0x3be00001
 patch=0x41810090,0x3be00000
 hash=0x3be00001,0x48000048
 patch=0x3be00000
+[sadmenu priiloader port]
+minversion=1
+maxversion=65535
+amount=3
+# icon.bin -> zcon.bin
+hash=0x69636f6e,0x2e62696e
+patch=0x7a636f6e,0x2e26296e
+# banner.bin -> zanner.bin
+hash=0x62616e6e,0x65722e62,0x696e
+patch=0x7a616e6e,0x65722e62,0x696e
+# sound.bin -> zound.bin
+hash=0x736f756e,0x642e6269,0x6e
+patch=0x7a6f756e,0x642e6269,0x6e


### PR DESCRIPTION
sadmenu is a homebrew app that patches the system menu on-the-fly to use zcon.bin, zanner.bin, and zound.bin instead of icon.bin, banner.bin, and sound.bin. I have ported the patches over to priiloader's hacks_hash.ini system.

tested on 4.3e, should work on any system menu version