### PR TITLE
Add Force Hide Photo Channel 1.0 hack

### DIFF
--- a/src/priiloader/hacks_hash.ini
+++ b/src/priiloader/hacks_hash.ini
@@ -731,3 +731,9 @@ hash=0x41810090,0x3be00001
 patch=0x41810090,0x3be00000
 hash=0x3be00001,0x48000048
 patch=0x3be00000
+[Force hide Photo Channel 1.0]
+maxversion=610
+minversion=256
+amount=1
+hash=0xa0030058,0x2800ff00
+patch=0x38000000,0x28000000


### PR DESCRIPTION
Causes the Wii to think that Photo channel 1.0 v65280 (the stub) is installed, which makes it hide it and show Photo channel 1.1 instead, if present